### PR TITLE
downgrade runner to ubuntu 22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   build_docker:    
     name: Build Docker
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -36,7 +36,7 @@ jobs:
   
   build_binary:    
     name: Build Binary
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ env:
 jobs:
   build_docker:    
     name: Build Docker
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -32,7 +32,7 @@ jobs:
 
   build_binary:    
     name: Build Binary
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 
@@ -40,7 +40,9 @@ jobs:
         run: |
           ./scripts/build.sh
           ./build/camino-conduit --version
-          tar -czvf camino-conduit-linux-amd64-${{ github.event.release.tag_name }}.tar.gz --directory=./build camino-conduit
+          mkdir -p ./build/camino-conduit-${{ github.event.release.tag_name }}
+          cp ./build/camino-conduit ./build/camino-conduit-${{ github.event.release.tag_name }}/
+          tar -czvf camino-conduit-linux-amd64-${{ github.event.release.tag_name }}.tar.gz --directory=./build camino-conduit-${{ github.event.release.tag_name }}
           
 
       - name: upload binary


### PR DESCRIPTION
* use ubuntu 22.04 runner for building
* put the binary in a directory "camino-conduit-{version}" before packing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the continuous integration environment to a specific Ubuntu version, ensuring more consistent and stable builds.
  - Reorganized release artifact packaging into a version-specific directory for clearer, more streamlined deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->